### PR TITLE
WIP: Playheads display

### DIFF
--- a/plugins/Ninjas2/Ninjas2Plugin.cpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.cpp
@@ -783,6 +783,7 @@ void NinjasPlugin::run ( const float**, float** outputs, uint32_t frames,       
                          }
                          // new note .. let's activate
                          voices[data1].active = true;
+                         voices[data1].notenumber = index;
                          voices[data1].velocity = data2;
                          voices[data1].gain = ( float ) data2 / 127.0f;
 

--- a/plugins/Ninjas2/Ninjas2Plugin.cpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.cpp
@@ -775,7 +775,7 @@ void NinjasPlugin::run ( const float**, float** outputs, uint32_t frames,       
                          break;
                     }
 
-                    case 0x90 : {
+                    case 0x90 : { // note on
                          //c4 is 60
                          int index = ( data1 + 68 ) % 128;
                          if ( index < 0 || index > Programs[programNumber].slices -1 ) {

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -804,6 +804,7 @@ void NinjasUI::onNanoDisplay()
 
           drawOnsets();
           drawRuler();
+          drawPlayheads();
      }
      // ninjas_logo
      const float logo_offset_x = display_left;
@@ -988,6 +989,28 @@ void NinjasUI::drawRuler()
      stroke();
      closePath();
 }
+
+
+void NinjasUI::drawPlayheads()
+{
+     // loop through active voices
+     for ( int i = 0 ; i < 128 ; i++ ) {
+          if ( plugin->voices[i].active ) {
+               int pos = plugin->voices[i].playbackIndex;
+               int gain = 255 * plugin->voices[i].gain;
+               // TODO: Check if in view?
+               printf("%i\n", pos);
+               beginPath();
+               strokeColor (gain, gain, gain, 255);
+               moveTo ( pos + display_left , display_top );
+               lineTo ( pos + display_left , display_bottom );
+               stroke();
+               closePath();
+          }
+     }
+
+}
+
 
 void NinjasUI::drawCurrentSlice()
 {

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -690,8 +690,7 @@ void NinjasUI::onNanoDisplay()
 
      closePath();
 
-     // waveform display back
-
+     // waveform display background
      beginPath();
      fillPaint (
           linearGradient
@@ -708,6 +707,7 @@ void NinjasUI::onNanoDisplay()
      closePath();
 
 
+     // parameter boxes
      beginPath();
      strokeWidth ( 2.0f );
      strokeColor ( Color ( 255,221,85,255 ) );
@@ -725,7 +725,6 @@ void NinjasUI::onNanoDisplay()
 
      // adsr box
      roundedRect ( 768 ,450 , 400, 110,  4 );
-
 
      stroke();
      closePath();
@@ -773,6 +772,7 @@ void NinjasUI::onNanoDisplay()
      fill();
      closePath();
 
+     // Settings labels
      beginPath();
      fontFaceId ( fNanoFont );
      fontSize ( 22 );

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -835,6 +835,13 @@ void NinjasUI::onNanoDisplay()
      closePath();
 }
 
+
+void NinjasUI::idleCallback()
+{
+     repaint();
+}
+
+
 void NinjasUI::drawWaveform()
 {
 //  waveView.end = 1140;
@@ -996,14 +1003,19 @@ void NinjasUI::drawPlayheads()
      // loop through active voices
      for ( int i = 0 ; i < 128 ; i++ ) {
           if ( plugin->voices[i].active ) {
-               int pos = plugin->voices[i].playbackIndex;
+               int sample_pos = plugin->voices[i].playbackIndex;
+               float samples_per_pixel =  pow ( waveView.max_zoom,waveView.zoom );
+               int pixel_pos = (float(sample_pos) - float(waveView.start)) / samples_per_pixel;
+               printf("sample_pos: %i\n", sample_pos);
+               printf("pixel_pos: %i\n", pixel_pos);
+
                int gain = 255 * plugin->voices[i].gain;
+
                // TODO: Check if in view?
-               printf("%i\n", pos);
                beginPath();
                strokeColor (gain, gain, gain, 255);
-               moveTo ( pos + display_left , display_top );
-               lineTo ( pos + display_left , display_bottom );
+               moveTo ( pixel_pos + display_left , display_top );
+               lineTo ( pixel_pos + display_left , display_bottom );
                stroke();
                closePath();
           }

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -1012,9 +1012,12 @@ void NinjasUI::drawPlayheads()
                                             - float(waveView.start))
                                    / samples_per_pixel;
 
+               if (pixel_pos < 0 || pixel_pos + display_left > display_right) {
+                    continue;
+               }
+
                int gain = std::min(int(255 * plugin->voices[i].adsr.adsr_gain), 255);
 
-               // TODO: Check if in view?
                beginPath();
                strokeColor (255, 255, 255, gain);
                moveTo ( pixel_pos + display_left , display_top );

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -1003,17 +1003,20 @@ void NinjasUI::drawPlayheads()
      // loop through active voices
      for ( int i = 0 ; i < 128 ; i++ ) {
           if ( plugin->voices[i].active ) {
+               int slice_num = plugin->voices[i].notenumber;
+               float slice_start = a_slices[slice_num].sliceStart;
+
                int sample_pos = plugin->voices[i].playbackIndex;
                float samples_per_pixel =  pow ( waveView.max_zoom,waveView.zoom );
-               int pixel_pos = (float(sample_pos) - float(waveView.start)) / samples_per_pixel;
-               printf("sample_pos: %i\n", sample_pos);
-               printf("pixel_pos: %i\n", pixel_pos);
+               int pixel_pos = (slice_start + float(sample_pos) / sampleChannels
+                                            - float(waveView.start))
+                                   / samples_per_pixel;
 
-               int gain = 255 * plugin->voices[i].gain;
+               int gain = std::min(int(255 * plugin->voices[i].gain), 255);
 
                // TODO: Check if in view?
                beginPath();
-               strokeColor (gain, gain, gain, 255);
+               strokeColor (255, 255, 255, gain);
                moveTo ( pixel_pos + display_left , display_top );
                lineTo ( pixel_pos + display_left , display_bottom );
                stroke();

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -1012,7 +1012,7 @@ void NinjasUI::drawPlayheads()
                                             - float(waveView.start))
                                    / samples_per_pixel;
 
-               int gain = std::min(int(255 * plugin->voices[i].gain), 255);
+               int gain = std::min(int(255 * plugin->voices[i].adsr.adsr_gain), 255);
 
                // TODO: Check if in view?
                beginPath();

--- a/plugins/Ninjas2/Ninjas2UI.hpp
+++ b/plugins/Ninjas2/Ninjas2UI.hpp
@@ -51,7 +51,8 @@ class NinjasUI : public UI,
      public NanoKnob::Callback,
      public NanoSwitch::Callback,
      public NanoSpinBox::Callback,
-     public NanoButton::Callback {
+     public NanoButton::Callback,
+     public IdleCallback {
 public:
      NinjasUI();
 
@@ -69,6 +70,7 @@ protected:
      // Widget Callbacks
 
      void onNanoDisplay() override;
+     void idleCallback() override;
      void nanoKnobValueChanged ( NanoKnob* nanoKnob, const float value ) override;
      void nanoSpinBoxValueChanged ( NanoSpinBox *nanoSpinBox, const float value ) override;
      void nanoSwitchClicked ( NanoSwitch* nanoSwitch, const MouseEvent &ev ) override;

--- a/plugins/Ninjas2/Ninjas2UI.hpp
+++ b/plugins/Ninjas2/Ninjas2UI.hpp
@@ -100,6 +100,7 @@ private:
      void drawOnsets();
      void drawSliceMarkers();
      void drawCurrentSlice();
+     void drawPlayheads();
      void getVisibleSlices ( int &firstSice, int &lastSlice );
      void selectSlice();
      void editCurrentSlice();


### PR DESCRIPTION
Fixes #30

Adds playheads that follow playing sample position.

Currently works with forward, reverse, multiple voices, and maps ADSR gain to playhead line transparency.

There is currently a problem where the playheads seem to continue slightly past the end of the slice, and I'm not sure why.