### PR TITLE
Onset sensitivity

### DIFF
--- a/plugins/Ninjas2/DistrhoPluginInfo.h
+++ b/plugins/Ninjas2/DistrhoPluginInfo.h
@@ -40,16 +40,17 @@ enum Parameters
     paramSigLoadProgram, // 2
     paramCurrentSlice, // 3
     paramNumberOfSlices, // 4
-    paramAttack, // 5
-    paramDecay, // 6
-    paramSustain, // 7
-    paramRelease, // 8
-    paramLoadSample, // 13
-    paramSliceMode, // 14
-    paramProgramGrid, // 15
-    paramPlayMode,
-    paramPitchbendDepth,
-    paramCount // 16
+    paramSliceSensitivity, // 5
+    paramAttack, // 6
+    paramDecay, // 7
+    paramSustain, // 8
+    paramRelease, // 9
+    paramLoadSample, // 10
+    paramSliceMode, // 11
+    paramProgramGrid, // 12
+    paramPlayMode, // 13
+    paramPitchbendDepth, // 14
+    paramCount // 15
 };
 
 

--- a/plugins/Ninjas2/Ninjas2Plugin.hpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.hpp
@@ -137,6 +137,7 @@ private:
   SLICEMODE enum_slicemode;
   //temp FIXME
   int slicemode;
+  float sliceSensitivity;
 
   enum stage_of_ADSR
   {

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -64,7 +64,7 @@ NinjasUI::NinjasUI()
 
      Window &window = getParentWindow();
 
-
+     // slice number selector
      fSpinBox = new SpinBox ( window, spinboxSize );
      fSpinBox->setId ( paramNumberOfSlices );
      fSpinBox->setRange ( 1.0f, 128.0f );
@@ -76,7 +76,7 @@ NinjasUI::NinjasUI()
      fSliceButton->setId ( 100 ); // FIXME don't hardcode this
      fSliceButton->setText ( "Slice" );
      fSliceButton->setFontSize ( 14.0f );
-     fSliceButton->setTextColor ( Color ( 255.0f,255.0f,255.0f,255.0f ) );
+     fSliceButton->setTextColor ( ninjasColor );
      fSliceButton->setMargin ( Margin ( 5,0,7,0 ) );
      fSliceButton->setCallback ( this );
 
@@ -180,16 +180,16 @@ void NinjasUI::positionWidgets()
      //const float width = getWidth();
      //const float height = getHeight();
 
-     fSpinBox->setAbsolutePos ( 222,486 );
-     fSliceButton->setAbsolutePos ( 222,451 );
+     fSpinBox->setAbsolutePos ( 302, 450 );
+     fSliceButton->setAbsolutePos ( 302, 531 );
 
      fKnobAttack->setAbsolutePos ( 791, 465 );
      fKnobDecay->setAbsolutePos ( 883, 465 );
      fKnobSustain->setAbsolutePos ( 975, 465 );
      fKnobRelease->setAbsolutePos ( 1067, 465 );
 
-     fSliceModeSlider->setAbsolutePos ( 275, 489 );
-     fLabelsBoxSliceModeSlider->setAbsolutePos ( 293, 484 );
+     fSliceModeSlider->setAbsolutePos ( 215, 458 );
+     fLabelsBoxSliceModeSlider->setAbsolutePos ( 235, 453 );
 
      fSwitchFwd->setAbsolutePos ( 592, 449 );
      fSwitchRev->setAbsolutePos ( 654, 449 );
@@ -697,7 +697,7 @@ void NinjasUI::onNanoDisplay()
      closePath();
 
      beginPath();
-     rect ( 252,431,60,18 ); // slices
+     rect ( 230,431,100,18 ); // slices
      fill();
      closePath();
 
@@ -738,7 +738,7 @@ void NinjasUI::onNanoDisplay()
      fillColor ( Color ( 255,221,85,255 ) );
      // const uint adsr_label_offset = 15;
      text ( 56,445,"sample",NULL );
-     text ( 253,445,"slices",NULL );
+     text ( 234,445,"slice tool",NULL );
      text ( 436,445,"states",NULL );
      text ( 589,444,"playmodes",NULL );
      text ( 795,455,"attack",NULL );

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -59,6 +59,7 @@ NinjasUI::NinjasUI()
 
      // knobs
      const Size<uint> knobSize = Size<uint> ( 80, 80 );
+     const Size<uint> knobSizeSmall = Size<uint> ( 40, 40 );
      const Size<uint> spinboxSize = Size<uint> ( 40,80 );
      const Color ninjasColor = Color ( 222,205,135,255 );
 
@@ -71,6 +72,11 @@ NinjasUI::NinjasUI()
      fSpinBox->setStep ( 1.0f );
      fSpinBox->setCallback ( this );
 
+     fKnobSliceSensitivity = new VolumeKnob ( window, knobSizeSmall );
+     fKnobSliceSensitivity->setId ( paramSliceSensitivity );
+     fKnobSliceSensitivity->setRange ( 0.001f, 1.0f );
+     fKnobSliceSensitivity->setColor ( ninjasColor );
+     fKnobSliceSensitivity->setCallback ( this );
 
      fSliceButton = new TextButton ( window, Size<uint> ( 40,30 ) );
      fSliceButton->setId ( 100 ); // FIXME don't hardcode this
@@ -112,6 +118,9 @@ NinjasUI::NinjasUI()
 
      fLabelsBoxSliceModeSlider = new GlowingLabelsBox ( window, Size<uint> ( 58, 42 ) );
      fLabelsBoxSliceModeSlider->setLabels ( {"RAW", "ONSETS"} );
+     fLabelsBoxSliceSensitivity = new GlowingLabelsBox ( window, Size<uint> ( 84, 21 ) );
+     fLabelsBoxSliceSensitivity->setLabels ( {"SENSITIVITY" } );
+
      fLabelsBoxLoadSample = new GlowingLabelsBox ( window, Size<uint> ( 90, 70 ) );
      fLabelsBoxLoadSample->setLabels ( {"Load Sample" } );
 
@@ -180,16 +189,18 @@ void NinjasUI::positionWidgets()
      //const float width = getWidth();
      //const float height = getHeight();
 
-     fSpinBox->setAbsolutePos ( 302, 450 );
-     fSliceButton->setAbsolutePos ( 302, 531 );
+     fSliceModeSlider->setAbsolutePos ( 217, 458 );
+     fLabelsBoxSliceModeSlider->setAbsolutePos ( 236, 453 );
+     fKnobSliceSensitivity->setAbsolutePos ( 237, 505 );
+     fLabelsBoxSliceSensitivity->setAbsolutePos ( 215, 543 );
+
+     fSpinBox->setAbsolutePos ( 307, 450 );
+     fSliceButton->setAbsolutePos ( 307, 532 );
 
      fKnobAttack->setAbsolutePos ( 791, 465 );
      fKnobDecay->setAbsolutePos ( 883, 465 );
      fKnobSustain->setAbsolutePos ( 975, 465 );
      fKnobRelease->setAbsolutePos ( 1067, 465 );
-
-     fSliceModeSlider->setAbsolutePos ( 215, 458 );
-     fLabelsBoxSliceModeSlider->setAbsolutePos ( 235, 453 );
 
      fSwitchFwd->setAbsolutePos ( 592, 449 );
      fSwitchRev->setAbsolutePos ( 654, 449 );

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -433,7 +433,7 @@ void NinjasUI::nanoKnobValueChanged ( NanoKnob* knob, const float value )
      case paramSliceSensitivity: {
           setParameterValue ( KnobID,value );
           if (sample_is_loaded) {
-              getOnsets(sampleSize, sampleChannels, sampleVector, onsets );
+              plugin->getOnsets();
           }
           break;
      }

--- a/plugins/Ninjas2/Ninjas2UI.cpp
+++ b/plugins/Ninjas2/Ninjas2UI.cpp
@@ -301,6 +301,9 @@ void NinjasUI::parameterChanged ( uint32_t index, float value )
      case paramSliceMode:
           fSliceModeSlider->setDown ( value > 0.5f );
           break;
+     case paramSliceSensitivity:
+          fKnobSliceSensitivity->setValue ( value );
+          break;
      case paramProgramGrid:
        //   printf ( "UI paramProgramGrid %f\n",value );
           programGrid = value;
@@ -425,6 +428,13 @@ void NinjasUI::nanoKnobValueChanged ( NanoKnob* knob, const float value )
           if ( oldValue != value )
                setProgramGrid ( programNumber );
           p_Release[currentSlice]=value;
+          break;
+     }
+     case paramSliceSensitivity: {
+          setParameterValue ( KnobID,value );
+          if (sample_is_loaded) {
+              getOnsets(sampleSize, sampleChannels, sampleVector, onsets );
+          }
           break;
      }
      default:
@@ -1260,6 +1270,7 @@ void NinjasUI::recallSliceSettings ( int slice )
      fKnobDecay->setValue ( p_Decay[slice] );
      fKnobSustain->setValue ( p_Sustain[slice] );
      fKnobRelease->setValue ( p_Release[slice] );
+
      fSwitchFwd->setDown ( p_playMode[slice] == ONE_SHOT_FWD );
      fSwitchRev->setDown ( p_playMode[slice] == ONE_SHOT_REV );
      fSwitchLoopFwd->setDown ( p_playMode[slice] == LOOP_FWD );

--- a/plugins/Ninjas2/Ninjas2UI.hpp
+++ b/plugins/Ninjas2/Ninjas2UI.hpp
@@ -80,10 +80,10 @@ protected:
      bool onMotion ( const MotionEvent& ) override;
 
 private:
-     ScopedPointer<VolumeKnob> fKnobAttack, fKnobDecay, fKnobSustain, fKnobRelease, fKnobSlices;
+     ScopedPointer<VolumeKnob> fKnobAttack, fKnobDecay, fKnobSustain, fKnobRelease, fKnobSliceSensitivity;
      ScopedPointer<SpinBox> fSpinBox;
      ScopedPointer<BipolarModeSwitch> fSliceModeSlider;
-     ScopedPointer<GlowingLabelsBox> fLabelsBoxSliceModeSlider, fLabelsBoxLoadSample;
+     ScopedPointer<GlowingLabelsBox> fLabelsBoxSliceModeSlider, fLabelsBoxSliceSensitivity, fLabelsBoxLoadSample;
      ScopedPointer<PlayModeSwitch> fSwitchFwd, fSwitchRev, fSwitchLoopFwd, fSwitchLoopRev;
      ScopedPointer<RemoveDCSwitch> fSwitchLoadSample;
      ScopedPointer<StateSwitch> fGrid[16];

--- a/plugins/Ninjas2/Widgets/src/GlowingLabelsBox.cpp
+++ b/plugins/Ninjas2/Widgets/src/GlowingLabelsBox.cpp
@@ -20,14 +20,14 @@ void GlowingLabelsBox::onNanoDisplay()
     const float height = getHeight();
 
     //Box background
-    beginPath();
+    // beginPath();
 
-    fillColor(Color(17, 17, 17, 255));
+    // fillColor(Color(17, 17, 17, 255));
 
-    rect(0, 0, width, height);
-    fill();
+    // rect(0, 0, width, height);
+    // fill();
 
-    closePath();
+    // closePath();
 
     const float labelSize = 14.0f;
     const float labelMarginLeft = 4.0f;

--- a/plugins/Ninjas2/Widgets/src/SpinBox.cpp
+++ b/plugins/Ninjas2/Widgets/src/SpinBox.cpp
@@ -2,13 +2,15 @@
 
 START_NAMESPACE_DISTRHO
 
+// TODO: Add all common colours to a central location, include them.
+const Color ninjasColor = Color ( 222,205,135,255 );
 
 SpinBox::SpinBox ( Window &parent, Size<uint> size ) noexcept :
 NanoSpinBox ( parent, size ),
             fText ( "+" ),
             fMargin ( Margin ( 0,0,0,0 ) ),
             fAlign ( ALIGN_TOP | ALIGN_LEFT ),
-            fTextColor ( Color ( 255,255,255,255 ) ),
+            fTextColor (ninjasColor),
             fFontSize ( 16.0f ),
             fFontId ( 0 ),
             fDigitsColor( Color (255,50,50,255))
@@ -19,7 +21,7 @@ NanoSpinBox ( parent, size ),
      decButton.setHeight(h/3);
      decButton.setPos(0, h/3 * 2);
      fDigitsClr0 = Color (255,50,50,255);
-     fDigitsClr1 = Color (0,0,0,255);
+     fDigitsClr1 = ninjasColor;
      loadSharedResources();
      parent.addIdleCallback ( this );
 }
@@ -29,7 +31,7 @@ NanoSpinBox ( widget, size ),
 fText ( "A" ),
 fMargin ( Margin ( 0,0,0,0 ) ),
 fAlign ( ALIGN_TOP | ALIGN_LEFT ),
-fTextColor ( Color ( 255,255,255,255 ) ),
+fTextColor (ninjasColor),
 fFontSize ( 16.0f ),
 fFontId ( 0 ),
 fDigitsColor( Color (255,50,50,255))
@@ -92,7 +94,7 @@ void SpinBox::draw()
 
 // digit background
      beginPath();
-     fillColor(Color(250,250,250,255));
+     fillColor(Color(40, 40, 40, 255));
      rect(margin,h/3,w-doubleMargin,h/3);
      fill();
      closePath();
@@ -113,7 +115,7 @@ void SpinBox::draw()
      }
      fontSize(26);
      fText = "+";
-     fillColor ( Color (200,200,200,255) );
+     fillColor (ninjasColor);
      textAlign ( fAlign );
      text ( 10, 0 , fText, NULL );
      closePath();

--- a/plugins/Ninjas2/Widgets/src/VolumeKnob.cpp
+++ b/plugins/Ninjas2/Widgets/src/VolumeKnob.cpp
@@ -7,7 +7,7 @@ VolumeKnob::VolumeKnob(Window &parent, Size<uint> size) noexcept : NanoKnob(pare
 
 {
     const float radius = size.getHeight() / 2.0f;
-    const float gaugeWidth = 3.5f;
+    const float gaugeWidth = 1.5 + radius / 20;
     const float diameter = (radius - gaugeWidth) * 2.0f - 4;
 
     fKnobICol = Color(86, 92, 95, 255);
@@ -17,7 +17,7 @@ VolumeKnob::VolumeKnob(Window &parent, Size<uint> size) noexcept : NanoKnob(pare
 
     fKnobDiameter = diameter;
 
-    fGrowAnimation = new FloatTransition(0.100f, &fKnobDiameter, fKnobDiameter - 7);
+    fGrowAnimation = new FloatTransition(0.100f, &fKnobDiameter, fKnobDiameter * 0.9);
     fHoverAnimation = new ColorTransition(0.200f, &fKnobOCol, fKnobTargetOCol);
 
     parent.addIdleCallback(this);
@@ -27,7 +27,7 @@ VolumeKnob::VolumeKnob(NanoWidget *widget, Size<uint> size) noexcept : NanoKnob(
 
 {
     const float radius = size.getHeight() / 2.0f;
-    const float gaugeWidth = 3.5f;
+    const float gaugeWidth = 1.5 + radius / 20;
     const float diameter = (radius - gaugeWidth) * 2.0f - 4;
 
     fKnobICol = Color(86, 92, 95, 255);
@@ -37,7 +37,7 @@ VolumeKnob::VolumeKnob(NanoWidget *widget, Size<uint> size) noexcept : NanoKnob(
 
     fKnobDiameter = diameter;
 
-    fGrowAnimation = new FloatTransition(0.100f, &fKnobDiameter, fKnobDiameter - 7);
+    fGrowAnimation = new FloatTransition(0.100f, &fKnobDiameter, fKnobDiameter * 0.9);
     fHoverAnimation = new ColorTransition(0.200f, &fKnobOCol, fKnobTargetOCol);
 
     widget->getParentWindow().addIdleCallback(this);
@@ -112,11 +112,11 @@ void VolumeKnob::draw()
 
     const float radius = height / 2.0f;
 
-    const float indicatorLineHeight = fKnobDiameter / 2.0f - 8;
-    const float indicatorLineWidth = 3.0f;
+    const float indicatorLineHeight = fKnobDiameter / 2.0f * 0.95;
+    const float indicatorLineWidth = 0.5 + radius / 20;
     const float indicatorLineMarginTop = 4.0f;
 
-    const float gaugeWidth = 3.5f;
+    const float gaugeWidth = 1.5 + radius / 20;
     Color gaugeColor = Color(0, 0, 40, 255);
     gaugeColor.interpolate(color, 0.4f);
 


### PR DESCRIPTION
This makes onset sensitivity customisable.

It also adjusts a few UI elements (removes dark patches behind labels, allows small knobs, better colours on the spinbox), so please check that you like it before merging.

I also changed the aubio onset detection algo to "specdiff", as it seemed to work better with the changeable sensitivity.

This doesn't affect slice creation, but it does seem to make the onset slicing work better - perhaps there are fewer duplicated onsets?
 