### PR TITLE
fix heap buffer overflow in getOnsets

### DIFF
--- a/plugins/Ninjas2/Ninjas2Plugin.cpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.cpp
@@ -1139,7 +1139,7 @@ void NinjasPlugin::getOnsets ()
      aubio_onset_t  * onset = new_aubio_onset ( "specdiff", win_s, hop_size, samplerate );
      aubio_onset_set_threshold ( onset, 1 - sliceSensitivity ) ;
      onsets.clear();
-     while ( readptr < tmp_sample_vector.size() ) {
+     while ( readptr + hop_size <= tmp_sample_vector.size() ) {
           ftable.data = &tmp_sample_vector[readptr];
           aubio_onset_do ( onset , &ftable, out );
           if ( out->data[0] != 0 ) {


### PR DESCRIPTION
There is a buffer overflow when the signals is read in fixed-size hops, at the tail of the input.
This patch omits the short final block which does not contain sufficient samples.