### PR TITLE
Fix/filepath display

### DIFF
--- a/plugins/Ninjas2/Widgets/LabelBox.hpp
+++ b/plugins/Ninjas2/Widgets/LabelBox.hpp
@@ -20,6 +20,7 @@
 #ifndef WOLF_LABEL_BOX_HPP_INCLUDED
 #define WOLF_LABEL_BOX_HPP_INCLUDED
 
+#include <string>
 #include "Widget.hpp"
 #include "NanoVG.hpp"
 
@@ -34,8 +35,8 @@ class LabelBox : public NanoWidget
     void setFontSize(float fontSize);
     float getFontSize();
 
-    void setText( const char *text);
-    const char *getText();
+    void setText(const std::string text);
+    const std::string getText();
 
     void setFontId(NanoVG::FontId fontId);
     NanoVG::FontId getFontId();
@@ -48,7 +49,7 @@ class LabelBox : public NanoWidget
     void onNanoDisplay() override;
 
   private:
-    const char *fText;
+    const std::string fText;
     float fFontSize;
     NanoVG::FontId fFontId;
     Color boxColor, borderColor, textColor;

--- a/plugins/Ninjas2/Widgets/src/LabelBox.cpp
+++ b/plugins/Ninjas2/Widgets/src/LabelBox.cpp
@@ -62,8 +62,8 @@ void LabelBox::onNanoDisplay()
     fontSize(fFontSize);
     fillColor(textColor);
     textAlign(ALIGN_LEFT | ALIGN_MIDDLE);
-    printf("getText() = %s\n",getText());
-    text(4, std::round(height / 2.0f + verticalMargin / 2.0f - 2), fText, NULL);
+    printf("getText() = %s\n",getText().c_str());
+    text(4, std::round(height / 2.0f + verticalMargin / 2.0f - 2), fText.c_str(), NULL);
     closePath();
 }
 
@@ -77,14 +77,14 @@ float LabelBox::getFontSize()
     return fFontSize;
 }
 
-void LabelBox::setText(const char *text)
+void LabelBox::setText(const std::string text)
 {
-    printf("setText(%s)\n",text);
+    printf("setText(%s)\n",text.c_str());
     fText = text;
  //   printf("fText =%s\n",fText);
 }
 
-const char *LabelBox::getText()
+const std::string LabelBox::getText()
 {
     return fText;
 }


### PR DESCRIPTION
Fixes rghvdberg/ninjas2#81

Change LabelBox to use std::string instead of char *

The string.c_str() function returns a pointer that is later reused for other purposes, and therefore the filename was lost..

I'm a bit rusty on C++ so I cannot say if we in some of the cases should use `std::string&` instead of `std::string`... It might imo get rid of some unnecessary copying..